### PR TITLE
ci: initialize SciPy submodule in setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contributing to SciR
 
+ - Ensure the SciPy git submodule is initialized (`scripts/setup-ci-env.sh` handles this) or run `git submodule update --init --depth 1 scipy`.
 - Run `python scripts/gen_fixtures.py -n 8` to regenerate test fixtures as needed.
 - Execute `pytest` and `cargo test` before committing changes.
 - Install pre-commit and run `pre-commit run --files <files>` on staged files.

--- a/PLAN.md
+++ b/PLAN.md
@@ -431,3 +431,6 @@ jobs:
 - Phase 2 complete: core signal routines and L-BFGS optimizer validated.
 - Added pre-commit hooks and updated contributing guidelines.
 - Removed SciPy git submodule; pip-installed SciPy satisfies fixture generation.
+- Phase 3 kick-off: reintroduced SciPy git submodule at `/scipy` and updated documentation references.
+- Updated CI setup script to initialize the SciPy submodule automatically.
+- Documented submodule path as `/scipy` and made setup script path-agnostic.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ This repository currently tracks early scaffolding work, including scripts for g
 
 ## Getting Started
 
-Run `scripts/setup-ci-env.sh` to install prerequisites.
+Run `scripts/setup-ci-env.sh` to install prerequisites and pull the SciPy submodule at `/scipy`.
 Install Python deps with `pip install -r requirements.txt` and run tests via `pytest` and `cargo test`.
+
+If you skipped the setup script, initialize the SciPy git submodule (checked out at `/scipy`) with:
+
+```
+git submodule update --init --depth 1 scipy
+```
 
 Generate reference FFT fixtures with `python scripts/gen_fixtures.py --sizes 8 16` (files land in `fixtures/`, which is git-ignored).
 Generate optimization fixtures with `python scripts/gen_optimize_fixtures.py` and signal fixtures with `python scripts/gen_signal_fixtures.py` (Butterworth, Chebyshev, Bessel, filtfilt, and `resample_poly` data). Optimization fixtures cover Nelder–Mead, BFGS, and L-BFGS results.

--- a/scripts/setup-ci-env.sh
+++ b/scripts/setup-ci-env.sh
@@ -2,7 +2,9 @@
 # Setup minimal environment for SciR CI builds.
 set -euo pipefail
 
-pip install -r requirements.txt
+repo_root="$(git rev-parse --show-toplevel)"
+git -C "$repo_root" submodule update --init --depth 1 scipy
+pip install -r "$repo_root/requirements.txt"
 
 # Install Rust using rustup
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable


### PR DESCRIPTION
## Summary
- auto-update the SciPy submodule via `setup-ci-env.sh`
- mention submodule pull in README and CONTRIBUTING
- log setup script update in project plan
- document submodule location at `/scipy` and make setup script path-agnostic

## Testing
- `bash -n scripts/setup-ci-env.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c00309971c833395aa786ac1f6b05a